### PR TITLE
Update hold-for-fan-mode.yaml

### DIFF
--- a/yaml-features/hold-for-fan-mode.yaml
+++ b/yaml-features/hold-for-fan-mode.yaml
@@ -207,14 +207,28 @@ script:
                 resp.service = "fan.turn_on";
 
                 HomeassistantServiceMap kv;
+                
+                if ( fan_speed == 0) {
+                  resp.service = "fan.turn_off";
 
-                kv.key = "entity_id";
-                kv.value = "$hass_fan_entity";
-                resp.data.push_back(kv);
+                  HomeassistantServiceMap kv;
+          
+                  kv.key = "entity_id";
+                  kv.value = "$hass_fan_entity";
+                  resp.data.push_back(kv);
+                } else {
+                  resp.service = "fan.turn_on";
 
-                kv.key = "percentage";
-                kv.value = to_string(fan_speed);
-                resp.data.push_back(kv);
+                  HomeassistantServiceMap kv;
+          
+                  kv.key = "entity_id";
+                  kv.value = "$hass_fan_entity";
+                  resp.data.push_back(kv);
+
+                  kv.key = "percentage";
+                  kv.value = to_string(fan_speed);
+                  resp.data.push_back(kv);
+                }
 
                 global_api_server->send_homeassistant_service_call(resp);
 


### PR DESCRIPTION
Problem:
- When sending 0% as speed to HASS it does not turn the fan off. In fact, that does not even work on HASS directly

Solution:
- Check if fan_speed = 0 than send  call 'turn_off' service instead of sending a step 0