### PR TITLE
Enable Extension of OTA Configurations

### DIFF
--- a/packages/profiles/stock-default.yaml
+++ b/packages/profiles/stock-default.yaml
@@ -147,9 +147,11 @@ api:
 # https://esphome.io/components/ota.html
 ota:
   - platform: web_server
+    id: kauf_web_server_ota
     on_error:
       - button.press: restart_button
   - platform: esphome
+    id: kauf_esphome_ota
     on_error:
       - button.press: restart_button
 

--- a/packages/profiles/stock-minimal.yaml
+++ b/packages/profiles/stock-minimal.yaml
@@ -55,7 +55,9 @@ api:
 # https://esphome.io/components/ota.html
 ota:
   - platform: web_server
+    id: kauf_web_server_ota
   - platform: esphome
+    id: kauf_esphome_ota
 
 
 safe_mode:

--- a/packages/shared/kauf-versioning.yaml
+++ b/packages/shared/kauf-versioning.yaml
@@ -2,6 +2,6 @@ substitutions:
   project_name: Kauf.RGBSw
 
   # Shared release/version knobs used across profiles and all platform targets.
-  project_ver_num: "1.396"
+  project_ver_num: "1.397"
   sub_min_version: 2026.3.0
   sub_common_ref: v2026.3.1


### PR DESCRIPTION

I have a custom configuration that adds a password to the `esphome` OTA platform inherited from the imported package:

```yaml
ota:
- platform: esphome
  password: !secret garage_refrigerator_ota_password
```

When I validate or compile this configuration I'm presented with a warning:

```
WARNING Found and merged multiple configurations for ota platform esphome port(s) [8266]
```

A [recent change in 2026.3.0](https://github.com/esphome/esphome/pull/14682) highlighted for me that there's a `!extend` syntax that is made for this purpose.  Unfortunately it does require upstream packages to add an `id` field to anything that needs to be extended.

This change adds the `id` field to every OTA configuration so that downstream users can create the following configuration that eliminates the warning:

```yaml
ota:
- id: !extend kauf_esphome_ota
  platform: esphome
  password: !secret garage_refrigerator_ota_password
```