### PR TITLE
Fix ESP8266 crash on color hold when syncing to HA light

### DIFF
--- a/yaml-features/rotate-colors-sync-to-ha-light.yaml
+++ b/yaml-features/rotate-colors-sync-to-ha-light.yaml
@@ -246,7 +246,7 @@ script:
                 call->init_data(2);
                 call->add_data("entity_id", "$hass_light_entity");
                 call->add_data("transition", "0");
-                call->init_data_template(0);
+                call->init_data_template(1);
                 call->add_data_template("rgb_color", "[" + esphome::to_string(red) + "," + esphome::to_string(green) + "," + esphome::to_string(blue) + "]");
                 call->init_variables(0);
                 call->play();
@@ -280,9 +280,9 @@ script:
                 call->init_data(2);
                 call->add_data("entity_id", "$hass_light_entity");
                 call->add_data("transition", "0");
-                call->init_data_template(2);
+                call->init_data_template(1);
                 call->add_data_template("rgb_color", "[" + to_string(red) + "," + to_string(green) + "," + to_string(blue) + "]");
-                call->init_variables(2);
+                call->init_variables(0);
                 call->play();
               }
             }


### PR DESCRIPTION
### Problem

When `rotate-colors-sync-to-ha-light.yaml` is used with `hass_light_entity` set, holding the button to cycle colors **reboots the switch** if the light is **on**. Hold with light **off** works (local LED only).

Crash on ESP8266:

```
Reason: Exception - StoreProhibit (exccause=29)
EXCVADDR: 0x00000000
```

### Cause

ESPHome 2025.11+ requires `init_data_template(n)` / `init_variables(n)` counts to match subsequent `add_*` calls (FixedVector). In `script_change_color`, `init_data_template(0)` is followed by one `add_data_template("rgb_color", ...)`. In `copy_val_to_light`, two template slots are reserved but only one is used.

Introduced when adapting HA service calls in eb168176 for ESPHome 2025.11.0.

### Fix

- `script_change_color`: `init_data_template(0)` → `init_data_template(1)`
- `copy_val_to_light`: `init_data_template(2)` → `init_data_template(1)`, `init_variables(2)` → `init_variables(0)`

### Testing

Verified on Kauf RGB Switch (SRF10 4MB), ESPHome 2026.6.2, with `hass_light_entity` pointing at a HA light group:

- Hold + light **on**: colors cycle on switch and HA entity, no reboot
- Hold + light **off**: switch LED cycles (unchanged behavior)
- Short press toggle: unchanged

Related: #23, #8

Fixes #37

Made with [Cursor](https://cursor.com)